### PR TITLE
Add console.log option. Closes #981.

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -60,6 +60,7 @@ The Console transport takes a few simple options:
 * __formatter:__ If function is specified, its return value will be used instead of default output. (default undefined)
 * __stderrLevels__ Array of strings containing the levels to log to stderr instead of stdout, for example `['error', 'debug', 'info']`. (default `['error', 'debug']`)
 * (Deprecated: Use __stderrLevels__ instead) __debugStdout:__ Boolean flag indicating if 'debug'-level output should be redirected to stdout instead of to stderr. Cannot be used with __stderrLevels__. (default false)
+* __useConsole:__ Boolean flag indicating if we should use `console.log` and `console.error` instead of `process.stdout.write` and `process.stderr.write` (for use with the v8-inspector debug protocol socket)
 
 *Metadata:* Logged via util.inspect(meta);
 
@@ -174,9 +175,9 @@ The Loggly transport is based on [Nodejitsu's][6] [node-loggly][7] implementatio
 
 ### Logzio Transport
 
-You can download the logzio transport here : [https://github.com/logzio/winston-logzio](https://github.com/logzio/winston-logzio)  
+You can download the logzio transport here : [https://github.com/logzio/winston-logzio](https://github.com/logzio/winston-logzio)
 
-*Basic Usage*  
+*Basic Usage*
 ```js
 var winston = require('winston');
 var logzioWinstonTransport = require('winston-logzio');

--- a/lib/winston/transports/console.js
+++ b/lib/winston/transports/console.js
@@ -33,6 +33,7 @@ var Console = exports.Console = function (options) {
   this.align        = options.align       || false;
   this.stderrLevels = setStderrLevels(options.stderrLevels, options.debugStdout);
   this.eol          = options.eol   || os.EOL;
+  this.useConsole   = options.useConsole  || false;
 
   if (this.json) {
     this.stringify = options.stringify || function (obj) {
@@ -116,9 +117,17 @@ Console.prototype.log = function (level, msg, meta, callback) {
   });
 
   if (this.stderrLevels[level]) {
-    process.stderr.write(output + this.eol);
+    if (this.useConsole) {
+      console.error(output);
+    } else {
+      process.stderr.write(output + this.eol);
+    }
   } else {
-    process.stdout.write(output + this.eol);
+    if (this.useConsole) {
+      console.log(output);
+    } else {
+      process.stdout.write(output + this.eol);
+    }
   }
 
   //


### PR DESCRIPTION
Add option to console transport to use console.log/error instead
of writing to process.stdout/stderr